### PR TITLE
Fix: Claude agents now explicitly use Bash tool for message sending

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,9 +11,14 @@
 - **worker1,2,3**: @instructions/worker.md
 
 ## メッセージ送信
+メッセージを送信するには、Bashツールを使用して以下のコマンドを実行してください：
 ```bash
 ./agent-send.sh [相手] "[メッセージ]"
 ```
 
 ## 基本フロー
-PRESIDENT → boss1 → workers → boss1 → PRESIDENT 
+PRESIDENT → boss1 → workers → boss1 → PRESIDENT
+
+## 重要な注意事項
+- メッセージ送信には必ずBashツールを使用してください
+- 指示書に従って行動する際は、記載されているbashコマンドを実行してください 

--- a/README.md
+++ b/README.md
@@ -57,6 +57,8 @@ tmux send-keys -t president 'claude --dangerously-skip-permissions' C-m
 for i in {0..3}; do tmux send-keys -t multiagent:0.$i 'claude --dangerously-skip-permissions' C-m; done
 ```
 
+**⚠️ 注意**: Claude Codeが起動したら、各エージェントはBashツールを使用してコマンドを実行します。直接コマンドを入力するのではなく、Claudeに指示を与えてBashツールでコマンドを実行させてください。
+
 ### 4. デモ実行
 
 PRESIDENTセッションで直接入力：
@@ -74,9 +76,13 @@ PRESIDENTセッションで直接入力：
 **Claude Code参照**: `CLAUDE.md` でシステム構造を確認
 
 **要点:**
-- **PRESIDENT**: 「あなたはpresidentです。指示書に従って」→ boss1に指示送信
-- **boss1**: PRESIDENT指示受信 → workers全員に指示 → 完了報告
+- **PRESIDENT**: 「あなたはpresidentです。指示書に従って」→ Bashツールでboss1に指示送信
+- **boss1**: PRESIDENT指示受信 → Bashツールでworkers全員に指示 → 完了報告
 - **workers**: Hello World実行 → 完了ファイル作成 → 最後の人が報告
+
+**⚠️ 重要な注意事項:**
+- 各エージェントはメッセージ送信時に必ずBashツールを使用してコマンドを実行する必要があります
+- 指示書に記載されているコマンドは、Claudeのインターフェースで直接実行するのではなく、Bashツールを通じて実行してください
 
 ## 🎬 期待される動作フロー
 
@@ -103,6 +109,8 @@ PRESIDENTセッションで直接入力：
 # エージェント一覧確認
 ./agent-send.sh --list
 ```
+
+**注意**: Claude Code内でメッセージを送信する場合は、Bashツールを使用して上記のコマンドを実行してください。
 
 ## 🧪 確認・デバッグ
 
@@ -143,6 +151,27 @@ rm -f ./tmp/worker*_done.txt
 # 再構築（自動クリア付き）
 ./setup.sh
 ```
+
+## 🐛 トラブルシューティング
+
+### PRESIDENTからBOSSにメッセージが送信されない場合
+
+1. **問題**: PRESIDENTが指示書に従ってもメッセージが送信されない
+   - **原因**: Claude CodeがBashツールを使用せずに直接コマンドを実行しようとしている
+   - **解決策**: 指示書が更新されていることを確認し、Claude Codeに「Bashツールを使用して」コマンドを実行するよう明示的に指示する
+
+2. **確認方法**:
+   ```bash
+   # 送信ログを確認
+   cat logs/send_log.txt | grep president
+   ```
+   PRESIDENTからの送信記録がない場合は、Bashツールが使用されていない
+
+3. **手動テスト**:
+   ```bash
+   # コマンドラインから直接テスト
+   ./agent-send.sh boss1 "テストメッセージ"
+   ```
 
 ---
 

--- a/instructions/boss.md
+++ b/instructions/boss.md
@@ -4,17 +4,20 @@
 チームメンバーの統括管理
 
 ## PRESIDENTから指示を受けたら実行する内容
-1. worker1,2,3に「Hello World 作業開始」を送信
+1. 以下のbashコマンドを実行してworker1,2,3に「Hello World 作業開始」を送信
 2. 最後に完了したworkerからの報告を待機
-3. PRESIDENTに「全員完了しました」を送信
+3. bashコマンドを実行してPRESIDENTに「全員完了しました」を送信
 
 ## 送信コマンド
+Bashツールを使用して以下のコマンドを実行してください：
 ```bash
 ./agent-send.sh worker1 "あなたはworker1です。Hello World 作業開始"
 ./agent-send.sh worker2 "あなたはworker2です。Hello World 作業開始"
 ./agent-send.sh worker3 "あなたはworker3です。Hello World 作業開始"
+```
 
-# 最後のworkerから完了報告受信後
+最後のworkerから完了報告受信後、以下を実行：
+```bash
 ./agent-send.sh president "全員完了しました"
 ```
 

--- a/instructions/president.md
+++ b/instructions/president.md
@@ -4,10 +4,11 @@
 プロジェクト全体の統括管理
 
 ## 「あなたはpresidentです。指示書に従って」と言われたら実行する内容
-1. boss1に「Hello World プロジェクト開始指示」を送信
+1. 以下のbashコマンドを実行してboss1に「Hello World プロジェクト開始指示」を送信
 2. 完了報告を待機
 
 ## 送信コマンド
+以下のbashコマンドを実行してください：
 ```bash
 ./agent-send.sh boss1 "あなたはboss1です。Hello World プロジェクト開始指示"
 ```

--- a/instructions/worker.md
+++ b/instructions/worker.md
@@ -10,15 +10,27 @@
 4. 全員完了していれば（自分が最後なら）boss1に報告
 
 ## 実行コマンド
+Bashツールを使用して以下のコマンドを順番に実行してください：
+
+1. Hello World表示:
 ```bash
 echo "Hello World!"
+```
 
-# 自分の完了ファイル作成
-touch ./tmp/worker1_done.txt  # worker1の場合
-# touch ./tmp/worker2_done.txt  # worker2の場合
-# touch ./tmp/worker3_done.txt  # worker3の場合
+2. 自分の完了ファイル作成（自分のworker番号に応じて実行）:
+```bash
+# worker1の場合
+touch ./tmp/worker1_done.txt
 
-# 全員の完了確認
+# worker2の場合
+touch ./tmp/worker2_done.txt
+
+# worker3の場合
+touch ./tmp/worker3_done.txt
+```
+
+3. 全員の完了確認と報告:
+```bash
 if [ -f ./tmp/worker1_done.txt ] && [ -f ./tmp/worker2_done.txt ] && [ -f ./tmp/worker3_done.txt ]; then
     echo "全員の作業完了を確認（最後の完了者として報告）"
     ./agent-send.sh boss1 "全員作業完了しました"
@@ -31,6 +43,4 @@ fi
 - 自分のworker番号に応じて適切な完了ファイルを作成
 - 全員完了を確認できたworkerが報告責任者になる
 - 最後に完了した人だけがboss1に報告する
-
-## 具体的な送信例
-- すべてのworker共通: `./agent-send.sh boss1 "全員作業完了しました"`
+- すべてのコマンドはBashツールを使用して実行する


### PR DESCRIPTION
## Summary
- Fixed the issue where PRESIDENT agent couldn't send messages to BOSS agent
- Updated all instruction files to explicitly require Bash tool usage
- Added troubleshooting section to README

## Problem
The PRESIDENT agent was unable to send messages to the BOSS agent because Claude Code was trying to execute commands directly instead of using the Bash tool. This caused the `agent-send.sh` script to not be executed properly.

## Solution
Updated all instruction files (`president.md`, `boss.md`, `worker.md`) and `CLAUDE.md` to explicitly state that commands must be executed using the Bash tool. Also updated README.md with:
- Clear warnings about Bash tool usage
- Troubleshooting section for this specific issue
- Updated workflow descriptions

## Changes
1. **instructions/president.md**: Added "Bashツールを使用して" (use Bash tool) instructions
2. **instructions/boss.md**: Clarified Bash tool usage for all commands
3. **instructions/worker.md**: Restructured to emphasize Bash tool usage
4. **CLAUDE.md**: Added explicit notes about using Bash tool for message sending
5. **README.md**: 
   - Added troubleshooting section
   - Added warnings in multiple sections
   - Updated workflow descriptions

## Test Plan
After applying these changes:
1. Run `./setup.sh` to create fresh tmux sessions
2. Start Claude Code in all sessions
3. Tell PRESIDENT: "あなたはpresidentです。指示書に従って"
4. Verify that PRESIDENT successfully sends message to BOSS
5. Check `logs/send_log.txt` to confirm message flow

🤖 Generated with [Claude Code](https://claude.ai/code)